### PR TITLE
Add session management and CSRF token refresh features

### DIFF
--- a/app/Http/Controllers/SessionController.php
+++ b/app/Http/Controllers/SessionController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Session;
+
+class SessionController extends Controller
+{
+    /**
+     * Keep session alive
+     */
+    public function keepAlive(Request $request): JsonResponse
+    {
+        // Regenerate session ID for security
+        $request->session()->migrate();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Session kept alive',
+            'timestamp' => now()->toISOString()
+        ]);
+    }
+
+    /**
+     * Refresh session and CSRF token
+     */
+    public function refresh(Request $request): JsonResponse
+    {
+        // Regenerate session ID
+        $request->session()->migrate();
+
+        // Regenerate CSRF token
+        $request->session()->regenerateToken();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Session refreshed',
+            'csrf_token' => $request->session()->token(),
+            'timestamp' => now()->toISOString()
+        ]);
+    }
+}

--- a/config/session.php
+++ b/config/session.php
@@ -1,0 +1,223 @@
+<?php
+
+use Illuminate\Support\Str;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Session Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default session "driver" that will be used on
+    | requests. By default, we will use the lightweight database driver, but
+    | you may specify any of the other wonderful drivers provided here.
+    |
+    | Supported: "file", "cookie", "database", "apc",
+    |            "memcached", "redis", "dynamodb", "array"
+    |
+    */
+
+    'driver' => env('SESSION_DRIVER', 'file'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Lifetime
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the number of minutes that you wish the session
+    | to be allowed to remain idle before it expires. If you want them
+    | to immediately expire on the browser closing, set that option.
+    |
+    */
+
+    'lifetime' => env('SESSION_LIFETIME', 720), // 12 hours (720 minutes)
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expire On Close
+    |--------------------------------------------------------------------------
+    |
+    | If this option is set to true, the session will expire immediately
+    | when the browser is closed. This option will override the lifetime
+    | option above.
+    |
+    */
+
+    'expire_on_close' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Encryption
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to easily specify that all of your session data
+    | should be encrypted before it is stored. All encryption will be run
+    | automatically by Laravel and you can use the Session like normal.
+    |
+    */
+
+    'encrypt' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session File Location
+    |--------------------------------------------------------------------------
+    |
+    | When using the native session driver, we need a location where session
+    | files may be stored. A default has been set for you but a different
+    | location may be specified. This is only needed for file sessions.
+    |
+    */
+
+    'files' => storage_path('framework/sessions'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | When using the "database" or "redis" session drivers, you may specify a
+    | connection that should be used to manage your sessions. This should
+    | correspond to a connection in your "database" configuration file.
+    |
+    */
+
+    'connection' => env('SESSION_CONNECTION'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Database Table
+    |--------------------------------------------------------------------------
+    |
+    | When using the "database" session driver, you may specify the table we
+    | should use to manage the sessions. Of course, a sensible default is
+    | provided for you; however, you are free to change this as needed.
+    |
+    */
+
+    'table' => 'sessions',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Cache Store
+    |--------------------------------------------------------------------------
+    |
+    | While using one of the framework's cache driven session backends you may
+    | list a cache store that should be used for these sessions. This value
+    | must match with one of the application's configured cache "stores".
+    |
+    | Default: null
+    |
+    */
+
+    'store' => env('SESSION_STORE'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Sweeping Lottery
+    |--------------------------------------------------------------------------
+    |
+    | Some session drivers must manually sweep their storage location to get
+    | rid of old sessions from storage. Here are the chances that it will
+    | happen on a given request. By default, the odds are 2 out of 100.
+    |
+    */
+
+    'lottery' => [2, 100],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Cookie Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may change the name of the cookie used to identify a session
+    | instance by ID. The name specified here will get used every time a
+    | new session cookie is created by the framework for every driver.
+    |
+    */
+
+    'cookie' => env(
+        'SESSION_COOKIE',
+        Str::slug(env('APP_NAME', 'laravel'), '_') . '_session'
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Cookie Path
+    |--------------------------------------------------------------------------
+    |
+    | The session cookie path determines the path for which the cookie will
+    | be regarded as available. Typically, this will be the root path of
+    | your application but you are free to change this when necessary.
+    |
+    */
+
+    'path' => '/',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Cookie Domain
+    |--------------------------------------------------------------------------
+    |
+    | Here you may change the domain of the cookie used to identify a session
+    | in your application. This will determine which domains the cookie is
+    | available to in your application. A sensible default has been set.
+    |
+    */
+
+    'domain' => env('SESSION_DOMAIN'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | HTTPS Only Cookies
+    |--------------------------------------------------------------------------
+    |
+    | By setting this option to true, session cookies will only be sent back
+    | to the server if the browser has a HTTPS connection. This will keep
+    | the cookie from being sent to you when it can't be done securely.
+    |
+    */
+
+    'secure' => env('SESSION_SECURE_COOKIE'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | HTTP Access Only
+    |--------------------------------------------------------------------------
+    |
+    | Setting this value to true will prevent JavaScript from accessing the
+    | value of the cookie and the cookie will only be accessible through
+    | the HTTP protocol. You are free to modify this option if needed.
+    |
+    */
+
+    'http_only' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Same-Site Cookies
+    |--------------------------------------------------------------------------
+    |
+    | This option determines how your cookies behave when cross-site requests
+    | take place, and can be used to mitigate CSRF attacks. By default, we
+    | will set this value to "lax" since this is a secure default value.
+    |
+    */
+
+    'same_site' => 'lax',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Partitioned Cookies
+    |--------------------------------------------------------------------------
+    |
+    | Setting this value to true will use the partitioned cookie attribute
+    | when creating cookies. This feature is currently supported by Chrome
+    | and other Chromium-based browsers.
+    |
+    */
+
+    'partitioned' => false,
+
+];

--- a/resources/js/Pages/BankAccounts/Create.vue
+++ b/resources/js/Pages/BankAccounts/Create.vue
@@ -135,6 +135,7 @@
 <script>
 import { Head, Link } from '@inertiajs/vue3'
 import Layout from '@/Shared/Layout.vue'
+import { useFormTokenRefresh } from '@/composables/useFormTokenRefresh.js'
 
 export default {
   components: {
@@ -143,6 +144,13 @@ export default {
   },
   layout: Layout,
   remember: 'form',
+  setup() {
+    const { ensureValidToken } = useFormTokenRefresh()
+    
+    return {
+      ensureValidToken
+    }
+  },
   data() {
     return {
       form: this.$inertia.form({
@@ -156,7 +164,10 @@ export default {
     }
   },
   methods: {
-    store() {
+    async store() {
+      // Ensure CSRF token is valid before submission
+      await this.ensureValidToken()
+      
       this.form.post('/bank-accounts')
     },
   },

--- a/resources/js/Pages/ExpenseClaims/Create.vue
+++ b/resources/js/Pages/ExpenseClaims/Create.vue
@@ -283,6 +283,7 @@
 <script>
 import { Head, Link } from '@inertiajs/vue3';
 import Layout from '@/Shared/Layout.vue';
+import { useFormTokenRefresh } from '@/composables/useFormTokenRefresh.js';
 
 export default {
   components: {
@@ -290,6 +291,13 @@ export default {
     Link,
   },
   layout: Layout,
+  setup() {
+    const { ensureValidToken } = useFormTokenRefresh();
+    
+    return {
+      ensureValidToken
+    };
+  },
   props: {
     referenceId: {
       type: String,
@@ -342,7 +350,10 @@ export default {
     removeItem(index) {
       this.form.items.splice(index, 1);
     },
-    submit() {
+    async submit() {
+      // Ensure CSRF token is valid before submission
+      await this.ensureValidToken();
+      
       this.form.post('/expense-claims');
     },
   },

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -4,6 +4,7 @@ import { createInertiaApp, router } from '@inertiajs/vue3'
 import { createPinia } from 'pinia'
 import { formatDate, formatAmount } from './Utils/formatters.js'
 import { usePermissionsStore } from './stores/permissions.js'
+import { useSessionKeepAlive } from './composables/useSessionKeepAlive.js'
 
 createInertiaApp({
   resolve: name => {
@@ -32,6 +33,9 @@ createInertiaApp({
         roles: props.initialPage.props.auth.userRoles || [],
         permissions: props.initialPage.props.auth.userPermissions || []
       })
+
+      // Initialize session keep-alive for authenticated users
+      useSessionKeepAlive()
     }
 
     // Make permissions available globally always (even if no user)

--- a/resources/js/composables/useFormTokenRefresh.js
+++ b/resources/js/composables/useFormTokenRefresh.js
@@ -1,0 +1,96 @@
+import { ref, onMounted } from 'vue'
+import { useSessionKeepAlive } from './useSessionKeepAlive.js'
+
+export function useFormTokenRefresh() {
+    const { refreshSession, updateCsrfToken } = useSessionKeepAlive()
+    const isRefreshing = ref(false)
+    const lastRefresh = ref(null)
+
+    // Configuration
+    const REFRESH_INTERVAL = 30 * 60 * 1000 // 30 minutes
+    const MIN_REFRESH_INTERVAL = 5 * 60 * 1000 // Minimum 5 minutes between refreshes
+
+    // Auto-refresh token before form submission
+    const ensureValidToken = async () => {
+        // Check if we need to refresh
+        if (shouldRefreshToken()) {
+            await refreshToken()
+        }
+    }
+
+    // Check if token should be refreshed
+    const shouldRefreshToken = () => {
+        if (!lastRefresh.value) return true
+
+        const timeSinceLastRefresh = Date.now() - lastRefresh.value
+        return timeSinceLastRefresh >= REFRESH_INTERVAL
+    }
+
+    // Refresh the CSRF token
+    const refreshToken = async () => {
+        if (isRefreshing.value) return false
+
+        // Prevent too frequent refreshes
+        if (lastRefresh.value && (Date.now() - lastRefresh.value) < MIN_REFRESH_INTERVAL) {
+            return false
+        }
+
+        isRefreshing.value = true
+
+        try {
+            const success = await refreshSession()
+            if (success) {
+                lastRefresh.value = Date.now()
+                console.log('Form token refreshed successfully')
+                return true
+            }
+            return false
+        } catch (error) {
+            console.error('Failed to refresh form token:', error)
+            return false
+        } finally {
+            isRefreshing.value = false
+        }
+    }
+
+    // Setup automatic token refresh
+    const setupAutoRefresh = () => {
+        // Refresh token every 30 minutes
+        const interval = setInterval(() => {
+            if (shouldRefreshToken()) {
+                refreshToken()
+            }
+        }, REFRESH_INTERVAL)
+
+        // Cleanup function
+        return () => clearInterval(interval)
+    }
+
+    // Manual token refresh (can be called from forms)
+    const manualRefresh = async () => {
+        return await refreshToken()
+    }
+
+    // Lifecycle
+    onMounted(() => {
+        // Initial token refresh if needed
+        if (shouldRefreshToken()) {
+            refreshToken()
+        }
+
+        // Setup auto-refresh
+        const cleanup = setupAutoRefresh()
+
+        // Return cleanup function
+        return cleanup
+    })
+
+    return {
+        isRefreshing,
+        lastRefresh,
+        ensureValidToken,
+        refreshToken,
+        manualRefresh,
+        setupAutoRefresh
+    }
+}

--- a/resources/js/composables/useSessionKeepAlive.js
+++ b/resources/js/composables/useSessionKeepAlive.js
@@ -1,0 +1,189 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+import { router } from '@inertiajs/vue3'
+
+export function useSessionKeepAlive() {
+    const isActive = ref(false)
+    const keepAliveInterval = ref(null)
+    const sessionTimeout = ref(null)
+    const lastActivity = ref(Date.now())
+
+    // Configuration
+    const KEEP_ALIVE_INTERVAL = 5 * 60 * 1000 // 5 minutes
+    const SESSION_WARNING_TIME = 10 * 60 * 1000 // 10 minutes before expiry
+    const SESSION_TIMEOUT = 11 * 60 * 1000 // 11 minutes (just before 12 hour expiry)
+
+    // Start session keep-alive
+    const startKeepAlive = () => {
+        if (isActive.value) return
+
+        isActive.value = true
+
+        // Set up periodic keep-alive requests
+        keepAliveInterval.value = setInterval(() => {
+            performKeepAlive()
+        }, KEEP_ALIVE_INTERVAL)
+
+        // Set up session timeout warning
+        sessionTimeout.value = setTimeout(() => {
+            showSessionWarning()
+        }, SESSION_WARNING_TIME)
+
+        // Track user activity
+        setupActivityTracking()
+
+        console.log('Session keep-alive started')
+    }
+
+    // Stop session keep-alive
+    const stopKeepAlive = () => {
+        if (!isActive.value) return
+
+        isActive.value = false
+
+        if (keepAliveInterval.value) {
+            clearInterval(keepAliveInterval.value)
+            keepAliveInterval.value = null
+        }
+
+        if (sessionTimeout.value) {
+            clearTimeout(sessionTimeout.value)
+            sessionTimeout.value = null
+        }
+
+        console.log('Session keep-alive stopped')
+    }
+
+    // Perform keep-alive request
+    const performKeepAlive = async () => {
+        try {
+            // Make a lightweight request to keep session alive
+            const response = await fetch('/api/session/keep-alive', {
+                method: 'GET',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'Accept': 'application/json',
+                },
+                credentials: 'same-origin'
+            })
+
+            if (response.ok) {
+                lastActivity.value = Date.now()
+                console.log('Session keep-alive successful')
+            } else {
+                console.warn('Session keep-alive failed, redirecting to login')
+                redirectToLogin()
+            }
+        } catch (error) {
+            console.error('Session keep-alive error:', error)
+            // Don't redirect on network errors, just log
+        }
+    }
+
+    // Show session timeout warning
+    const showSessionWarning = () => {
+        const warningMessage = 'Your session will expire soon. Would you like to extend it?'
+
+        if (confirm(warningMessage)) {
+            // User wants to extend session
+            performKeepAlive()
+
+            // Reset the warning timer
+            sessionTimeout.value = setTimeout(() => {
+                showSessionWarning()
+            }, SESSION_WARNING_TIME)
+        } else {
+            // User declined, redirect to login
+            redirectToLogin()
+        }
+    }
+
+    // Redirect to login
+    const redirectToLogin = () => {
+        stopKeepAlive()
+        router.visit('/login')
+    }
+
+    // Setup activity tracking
+    const setupActivityTracking = () => {
+        const events = ['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart', 'click']
+
+        const updateActivity = () => {
+            lastActivity.value = Date.now()
+        }
+
+        events.forEach(event => {
+            document.addEventListener(event, updateActivity, true)
+        })
+
+        // Cleanup function for activity tracking
+        return () => {
+            events.forEach(event => {
+                document.removeEventListener(event, updateActivity, true)
+            })
+        }
+    }
+
+    // Manual session refresh (for forms)
+    const refreshSession = async () => {
+        try {
+            const response = await fetch('/api/session/refresh', {
+                method: 'POST',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'Accept': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
+                },
+                credentials: 'same-origin'
+            })
+
+            if (response.ok) {
+                const data = await response.json()
+                // Update CSRF token if provided
+                if (data.csrf_token) {
+                    updateCsrfToken(data.csrf_token)
+                }
+                lastActivity.value = Date.now()
+                return true
+            }
+            return false
+        } catch (error) {
+            console.error('Session refresh error:', error)
+            return false
+        }
+    }
+
+    // Update CSRF token in meta tag and forms
+    const updateCsrfToken = (newToken) => {
+        // Update meta tag
+        const metaTag = document.querySelector('meta[name="csrf-token"]')
+        if (metaTag) {
+            metaTag.setAttribute('content', newToken)
+        }
+
+        // Update all hidden CSRF input fields
+        const csrfInputs = document.querySelectorAll('input[name="_token"]')
+        csrfInputs.forEach(input => {
+            input.value = newToken
+        })
+
+        console.log('CSRF token updated')
+    }
+
+    // Lifecycle hooks
+    onMounted(() => {
+        startKeepAlive()
+    })
+
+    onUnmounted(() => {
+        stopKeepAlive()
+    })
+
+    return {
+        isActive,
+        lastActivity,
+        startKeepAlive,
+        stopKeepAlive,
+        refreshSession,
+        updateCsrfToken
+    }
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html class="h-full bg-gray-100">
+
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 
     {{-- Inertia --}}
@@ -14,7 +16,9 @@
     @vite('resources/js/app.js')
     @inertiaHead
 </head>
+
 <body class="font-sans leading-none text-gray-700 antialiased">
     @inertia
 </body>
+
 </html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\SessionController;
+
+/*
+|--------------------------------------------------------------------------
+| API Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register API routes for your application. These
+| routes are loaded by the RouteServiceProvider and all of them will
+| be assigned to the "api" middleware group. Make something great!
+|
+*/
+
+Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+    return $request->user();
+});
+
+// Session management routes
+Route::middleware(['web', 'auth'])->group(function () {
+    Route::get('/session/keep-alive', [SessionController::class, 'keepAlive']);
+    Route::post('/session/refresh', [SessionController::class, 'refresh']);
+});


### PR DESCRIPTION
- Implemented extended session lifetime from 2 hours to 12 hours.
- Introduced a session keep-alive system with automatic requests every 5 minutes and user activity tracking.
- Added CSRF token refresh functionality, automatically updating tokens every 30 minutes.
- Created API endpoints for session management: `GET /api/session/keep-alive` and `POST /api/session/refresh`.
- Updated relevant files including session configuration, API routes, and Vue components to integrate new features and ensure seamless user experience.